### PR TITLE
add missing requirements to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,9 @@
 requires 'AnyEvent', '5.33';
 requires 'AnyEvent::HTTP', '2.15';
+requires 'JSON';
+requires 'LWP::UserAgent';
+requires 'Sub::Install';
+requires 'Sub::Name';
 
 on 'test' => sub {
     requires 'Plack';


### PR DESCRIPTION
Michael noticed these requirements were missing from the cpanfile while trying to run under perlbrew.
