### PR TITLE
Update debian dependency on libanyevent-http-perl

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libnessy-client-perl (0.010-2) lucid; urgency=low
+
+  * Update libanyevent-http-perl dependency version to 2.15-3
+
+ -- Mark Burnett <mburnett@genome.wustl.edu>  Wed, 24 Dec 2014 13:43:47 -0600
+
 libnessy-client-perl (0.010-1) lucid; urgency=low
 
   * Implement new state machine based backend.

--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: libnessy-client-perl
 Section: perl
 Priority: optional
 Build-Depends: debhelper (>= 7), perl (>= 5.8.0)
-Build-Depends-Indep: perl (>= 5.8.0), libtest-simple-perl, libjson-perl, libanyevent-perl, libanyevent-http-perl (>= 2.15), libsub-name-perl, libsub-install-perl, libplack-perl, libwww-perl
+Build-Depends-Indep: perl (>= 5.8.0), libtest-simple-perl, libjson-perl, libanyevent-perl, libanyevent-http-perl (>= 2.15-3), libsub-name-perl, libsub-install-perl, libplack-perl, libwww-perl
 Maintainer: Anthony Brummett <abrummet@genome.wustl.edu>
 Standards-Version: 3.8.3
 Homepage: https://github.com/genome/nessy-client-perl
 
 Package: libnessy-client-perl
 Architecture: all
-Depends: ${perl:Depends}, ${misc:Depends}, perl (>= 5.8.0), libjson-perl, libanyevent-perl, libanyevent-http-perl (>= 2.15), libsub-name-perl, libsub-install-perl
+Depends: ${perl:Depends}, ${misc:Depends}, perl (>= 5.8.0), libjson-perl, libanyevent-perl, libanyevent-http-perl (>= 2.15-3), libsub-name-perl, libsub-install-perl
 Description: Perl client for the Nessy locking server


### PR DESCRIPTION
The 2.15-2 package did not have the correct version of libanyevent-perl specified in `Depends` (the correct dependency was being specified for the `Build-Depends`).  This updates the nessy client package to depend on the updated libanyevent-http-perl package.

@mkiwala and I found this issue while doing integration testing with Genome.  It manifested as repeatable failures of HTTP requests to the nessy server (specifically while performing validate).  We noticed that the version of `AnyEvent` installed on the workstations was 5.24 and that `AnyEvent::HTTP` (veresion 2.15) requires at least version 5.33.  When looking at the genome-vendor package for libanyevent-http-perl, we noticed that the dependency had been fixed for `Build-Depends`, but not for `Depends`.  Updating the version of libanyevent-perl to 5.340 fixes the problem on our workstations, so we updated the libanyevent-http-perl package.

Below is the script that caused the failures on workstations ONLY.  The issue did not manifest on our laptops:

``` perl
#!/usr/bin/env perl

use strict;
use warnings;

use Data::Dumper;
use List::Util qw(shuffle);
use Nessy::Client;

sub random_string {
    my @chars = map { (shuffle 'a'..'z', 'A'..'Z', 0..9)[0] } 1..10;
    return join('', @chars);
}

sub main {
    my $client = Nessy::Client->new(url => 'http://nessy');

    my $claim = $client->claim('BREAKIT-' . random_string());

    print Dumper($claim->validate);  # Succeeds, returning 1.
    print Dumper($claim->validate);  # This call (and all subsequent calls to validate) fails, returning ''.

    $claim->release;
}

main();
```
