### PR TITLE
404 error

### DIFF
--- a/lib/Nessy/Daemon.pm
+++ b/lib/Nessy/Daemon.pm
@@ -411,6 +411,19 @@ sub submit_url {
 
 sub _claim_activated {
     my ($self, $resource_name) = @_;
+    $self->_claim_activated_or_register_failed($resource_name, 'succeed');
+}
+
+sub _claim_register_failed {
+    my($self, $resource_name) = @_;
+    $self->_claim_activated_or_register_failed($resource_name, 'fail');
+
+    $self->_log_claim_failure($resource_name,
+        "Got error while registering claim");
+}
+
+sub _claim_activated_or_register_failed {
+    my($self, $resource_name, $result) = @_;
 
     my $serial = $self->_get_message_serial('claim', $resource_name);
     my $message = Nessy::Client::Message->new(
@@ -419,11 +432,10 @@ sub _claim_activated {
         serial => $serial,
     );
 
-    $message->succeed;
+    $message->$result;
 
     $self->_send_return_message($message);
 }
-
 
 sub _log_claim_failure {
     my ($self, $resource_name, $message) = @_;

--- a/lib/Nessy/Daemon.pm
+++ b/lib/Nessy/Daemon.pm
@@ -346,6 +346,7 @@ sub _construct_callbacks {
             $self->_log_claim_failure($resource_name,
                 "Got shutdown on new claim");
         },
+        on_register_error => sub { $self->_claim_register_failed($resource_name) },
 
         # Dirty failures
         on_register_timeout => sub {
@@ -371,10 +372,6 @@ sub _construct_callbacks {
         on_withdraw_shutdown => sub {
             $self->_log_claim_failure($resource_name,
                 "Got shutdown while withdrawing claim");
-        },
-        on_register_error => sub {
-            $self->_log_claim_failure($resource_name,
-                "Got error while registering claim");
         },
         on_activate_error => sub {
             $self->_log_claim_failure($resource_name,

--- a/t/Nessy/claim.t
+++ b/t/Nessy/claim.t
@@ -5,14 +5,10 @@ use warnings;
 
 use Nessy::Claim;
 
-use Test::More tests => 17;
+use Test::More tests => 4;
 
-test_failing_constructor();
-test_release();
-test_destructor();
-test_validate();
-
-sub test_failing_constructor {
+subtest 'failing constructor' => sub {
+    plan tests => 7;
 
     my $claim;
 
@@ -30,9 +26,11 @@ sub test_failing_constructor {
         ok(! $claim, "omitting $omit param does not return new object");
         like($@, qr($omit is a required param), "new() without $omit throws expected exception");
     }
-}
+};
 
-sub test_release {
+subtest release => sub {
+    plan tests => 6;
+
     my $resource_name = 'foo';
 
     my($on_release_called, $on_validate_called) = (0, 0);
@@ -50,9 +48,11 @@ sub test_release {
 
     is($on_release_called, 1, 'on_release callback was not called again');
     is($on_validate_called, 0, 'on_validate callback was not called');
-}
+};
 
-sub test_destructor {
+subtest destructor => sub {
+    plan tests => 2;
+
     my $resource_name = 'foo';
 
     my $on_release_called = 0;
@@ -64,15 +64,16 @@ sub test_destructor {
     undef($claim);
 
     is($on_release_called, 1, 'on_release called once in destructor');
-}
+};
 
-sub test_validate {
+subtest validate => sub {
+    plan tests => 2;
     my $on_validate_called = 0;
     my $on_validate = sub { $on_validate_called++; 1};
     my $claim = Nessy::Claim->new(resource_name => 'foo', on_release => sub {}, on_validate => $on_validate);
 
     ok($claim->validate, 'on_validate');
     is($on_validate_called, 1, 'on_validate callback was called');
-}
+};
 
 

--- a/t/Nessy/client_message.t
+++ b/t/Nessy/client_message.t
@@ -6,25 +6,19 @@ use warnings;
 use Nessy::Client::Message;
 use JSON;
 
-use Test::More tests => 33;
+use Test::More tests => 5;
 
-test_constructor();
-test_constructor_and_properties();
-test_failed_constructor();
+subtest constructor => sub {
+    plan tests => 3;
 
-test_encode();
-
-test_success_fail();
-
-
-sub test_constructor {
     my $m = Nessy::Client::Message->new(resource_name => 'foo', command => 'bar', serial => 1);
     ok($m, 'constructor');
     is($m->resource_name, 'foo', 'resource_name property');
     is($m->command, 'bar', 'command property');
-}
+};
 
-sub test_constructor_and_properties {
+subtest 'constructor and properties' => sub {
+    plan tests => 6;
 
     my @construction_params = (resource_name => 'foo', command => 'bar', serial => 1);
     my @remaining_params = (args => 123, result => 'abc', error_message => 'hi');
@@ -42,9 +36,11 @@ sub test_constructor_and_properties {
         }
         ok($is_ok, "accessor with $params_count properties");
     }
-}
+};
 
-sub test_failed_constructor {
+subtest 'failed constructor' => sub {
+    plan tests => 4;
+
     my $m = eval { Nessy::Client::Message->new() };
     ok($@, 'new() throws exception with no args');
 
@@ -60,9 +56,11 @@ sub test_failed_constructor {
         my $m = eval { Nessy::Client::Message->new( %params ) };
         like($@, qr($omit is a required param), "constructor fails when missing $omit");
     }
-}
+};
 
-sub test_encode {
+subtest encode => sub {
+    plan tests => 4;
+
     my %params = (
         resource_name => 'foo',
         command => 'bar',
@@ -90,9 +88,11 @@ sub test_encode {
         $is_ok = 0 if ($m->$key ne $params{$key});
     }
     ok($is_ok, 'json copy succeeded');
-}
+};
 
-sub test_success_fail {
+subtest 'success/fail' => sub {
+    plan tests => 16;
+
     my $m = Nessy::Client::Message->new( command => 'hi', resource_name => 'foo', serial => 1);
     ok($m, 'new message');
     ok($m->succeed, 'Set message successful');
@@ -117,4 +117,4 @@ sub test_success_fail {
 
     ok(! eval { $m->fail }, 'Could not change status after it was set');
     like($@, qr(Cannot set Message to failed), 'exception');
-}
+};

--- a/t/Nessy/integration.t
+++ b/t/Nessy/integration.t
@@ -122,6 +122,20 @@ subtest shutdown_released_claim_doesnt_crash => sub {
     lives_ok {$client->shutdown} "client shutdown doesn't crash";
 };
 
+subtest 'bad URL' => sub {
+    plan tests => 2;
+
+    local $ENV{NESSY_SERVER_URL} = $ENV{NESSY_SERVER_URL} . '/bad';
+    my $resource = _get_resource();
+    my $client = _get_client();
+    local $SIG{ALRM} = sub { die 'timed out' };
+
+    alarm(30);
+    my $claim = eval { $client->claim($resource) };
+    ok(! $claim, 'getting a claim with bad URL failed');
+    is($@, '', 'no exception getting claim');
+};
+
 
 done_testing();
 

--- a/t/Nessy/properties.t
+++ b/t/Nessy/properties.t
@@ -3,27 +3,35 @@
 use strict;
 use warnings;
 
-use Test::More tests => 12;
+use Test::More tests => 4;
 
-{
+subtest 'property names' => sub {
+    plan tests => 1;
+
     my @properties = sort Nessy::Test::Class->__property_names();
     is_deeply(\@properties, [ qw(prop_a prop_b) ], '__property_names()');
-}
+};
 
-{
+subtest constructor => sub {
+    plan tests => 2;
+
     my $obj = eval { Nessy::Test::Class->new() };
     ok(! $obj, 'constructor fails with no params');
     like($@, qr(prop_a is a required param), 'Exception');
-}
+};
 
-{
+subtest create => sub {
+    plan tests => 3;
+
     my $obj = Nessy::Test::Class->new(prop_a => 1);
     ok($obj, 'Created object with required param');
     is($obj->prop_a, 1, 'prop_a');
     is($obj->prop_b, undef, 'prop_b');
-}
+};
 
-{
+subtest params => sub {
+    plan tests => 6;
+
     my %obj1_params = (prop_a => 'a', prop_b => 'b');
     my %obj2_params = (prop_a => 1, prop_b => 2);
     my $obj1 = Nessy::Test::Class->new(%obj1_params);
@@ -41,7 +49,7 @@ use Test::More tests => 12;
 
     $check_params->($obj1, \%obj1_params);
     $check_params->($obj2, \%obj2_params);
-}
+};
 
 package Nessy::Test::Class;
 


### PR DESCRIPTION
This fixes the hanging problem where an attempt to lock using a bogus URL would hang.

There may be other failure states that could also hang.  We need to look closely at the state machine definition and check.