### PR TITLE
Don't block when the daemon dies

### DIFF
--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -71,15 +71,21 @@ sub _parent_process_setup {
     my $watcher = $self->_create_socket_watcher($params{socketpair}->[0]);
     $self->socket_watcher($watcher);
 
-    $params{socketpair}->[1]->close();
+    $self->_close_unused_socket($params{socketpair}->[1]);
 }
 
+# After forking, the parent closes the child's socket, and the child closes
+# the parent's socket
+sub _close_unused_socket {
+    my($self, $sock) = @_;
+    $sock->close();
+}
 
 sub _run_child_process {
     my($class, %params) = @_;
 
     eval {
-        $params{socketpair}->[0]->close();
+        $class->_close_unused_socket($params{socketpair}->[0]);
         my $daemon_class = $class->_daemon_class_name;
         my $daemon = $daemon_class->new(
                             url => $params{url},

--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -377,7 +377,7 @@ sub _on_read_event {
 
 sub bailout {
     my($self, $message) = @_;
-    print STDERR $message,"\n";
+    print STDERR "nessy: ",$message,"\n";
     $self->_fail_outstanding_requests($message);
     $self->socket_watcher(undef);
 }

--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -48,7 +48,9 @@ sub _verify_constructor_params {
 
     $params->{api_version} ||= $class->_default_api_version;
     $params->{url} || Carp::croak('url is a required param');
-    $params->{'socketpair'} ||= [ $class->_make_socket_pair_for_daemon_comms() ];
+    $params->{socketpair} ||= [ $class->_make_socket_pair_for_daemon_comms() ];
+    $params->{default_ttl} ||= $class->_default_ttl;
+    $params->{default_timeout} ||= $class->_default_timeout;
 
     return $params;
 }
@@ -64,8 +66,8 @@ sub _parent_process_setup {
     my($self, %params) = @_;
 
     $self->api_version($params{api_version});
-    $self->default_ttl( $params{default_ttl} || $self->_default_ttl );
-    $self->default_timeout( $params{default_timeout} || $self->_default_timeout );
+    $self->default_ttl($params{default_ttl});
+    $self->default_timeout($params{default_timeout});
     $self->serial_responder_registry({});
 
     my $watcher = $self->_create_socket_watcher($params{socketpair}->[0]);

--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -311,7 +311,7 @@ sub _register_responder_for_message {
     my($self, $responder, $message) = @_;
 
     my $registry = $self->serial_responder_registry;
-    $registry->{ $message->serial } = $responder;
+    $registry->{ $message->serial } = [ $responder, $message ];
 }
 
 sub _daemon_response_handler {
@@ -319,7 +319,7 @@ sub _daemon_response_handler {
 
     my $registry = $self->serial_responder_registry;
     my $serial = $message->serial;
-    my $responder = delete $registry->{$serial};
+    my($responder, $orig_message) = @{ delete $registry->{$serial} };
 
     $self->bailout('no responder for message '.$message->serial) unless ($responder);
 

--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -31,7 +31,7 @@ sub new {
 
     my($socket1, $socket2) = $class->_make_socket_pair_for_daemon_comms();
 
-    my $pid = _fork();
+    my $pid = $class->_fork();
     if ($pid) {
         my $self = bless {}, $class;
         $self->api_version($api_version);

--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -26,9 +26,8 @@ my $MESSAGE_SERIAL = 1;
 sub new {
     my($class, %params) = @_;
 
-    my $api_version = $params{api_version} || $class->_default_api_version;
-
-    my $url = $params{url} || Carp::croak('url is a required param');
+    $class->_verify_constructor_params(\%params);
+    my($api_version,$url) = @params{'api_version','url'};
 
     my($socket1, $socket2) = IO::Socket->socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC);
 
@@ -65,6 +64,14 @@ sub new {
     } else {
         Carp::croak("Can't fork: $!");
     }
+}
+
+sub _verify_constructor_params {
+    my($class, $params) = @_;
+
+    $params->{api_version} ||= $class->_default_api_version;
+    $params->{url} || Carp::croak('url is a required param');
+    return $params;
 }
 
 sub _default_ttl { 60 } # seconds

--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -357,7 +357,7 @@ sub _on_read_event {
 
 sub bailout {
     my($self, $message) = @_;
-    Carp::croak($message);
+    print STDERR $message,"\n";
 }
 
 1;

--- a/lib/Nessy/Client.pm
+++ b/lib/Nessy/Client.pm
@@ -29,9 +29,7 @@ sub new {
     $class->_verify_constructor_params(\%params);
     my($api_version,$url) = @params{'api_version','url'};
 
-    my($socket1, $socket2) = IO::Socket->socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC);
-
-    $_->autoflush(1) foreach ($socket1, $socket2);
+    my($socket1, $socket2) = $class->_make_socket_pair_for_daemon_comms();
 
     my $pid = _fork();
     if ($pid) {
@@ -73,6 +71,14 @@ sub _verify_constructor_params {
     $params->{url} || Carp::croak('url is a required param');
     return $params;
 }
+
+sub _make_socket_pair_for_daemon_comms {
+    my($socket1, $socket2) = IO::Socket->socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC);
+    $_->autoflush(1) foreach ($socket1, $socket2);
+
+    return ($socket1, $socket2);
+}
+
 
 sub _default_ttl { 60 } # seconds
 sub _default_timeout { undef } # seconds or undef means wait as long as it takes

--- a/t/Nessy/daemon_dies_after_request.t
+++ b/t/Nessy/daemon_dies_after_request.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Nessy::Client;
+use AnyEvent;
+
+# test that the client does not hang if the daemon's socket closes while we're
+# waiting on a response
+
+my $client = Nessy::Test::Client->new(url => 'http://localhost/');
+ok($client, 'created new client');
+
+my $w;
+$w = AnyEvent->io(fh => $client->daemon_to_client_sock,
+             poll => 'r',
+             # when the client sends the daemon a lock request, close
+             # the socket to simulate the daemon going away
+             cb => sub {
+                        ok(1, 'Got message from client to make a lock');
+                        $client->daemon_to_client_sock->close(),
+                        undef $w;
+                      },
+        );
+
+$SIG{ALRM} = sub { die "timed out" };
+alarm(30);
+my $warning_message;
+$SIG{__WARN__} = sub { $warning_message = shift };
+my $claim_name = 'foo';
+my $claim = eval { $client->claim($claim_name) };
+
+ok(! $claim, "couldn't make a claim when the daemon closed its socket");
+ok(!$@, 'no exception');
+like($warning_message,
+    qr(claim $claim_name at .* failed: Connection reset by peer),
+    'warning message');
+
+
+package Nessy::Test::Client;
+use base 'Nessy::Client';
+
+my($client_to_daemon_sock, $daemon_to_client_sock);
+sub _make_socket_pair_for_daemon_comms {
+    my $self = shift;
+    ($client_to_daemon_sock, $daemon_to_client_sock) = $self->SUPER::_make_socket_pair_for_daemon_comms;
+    return ($client_to_daemon_sock, $daemon_to_client_sock);
+}
+
+sub daemon_to_client_sock { $daemon_to_client_sock }
+
+sub _fork { $$ }  # Don't fork
+sub _close_unused_socket {} # don't close
+
+sub _run_child_process {} 


### PR DESCRIPTION
If the daemon went away, the client would get notified of the EOF, but wouldn't relay that info to whatever was waiting on a response.

This changes it so any outstanding requests get notified of failure if the socket to the daemon closes.

The first several commits is just refactoring to make a test case easier to write.  The last 2 fix the problem.